### PR TITLE
Ros model syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This create a snapshot in a yaml format then finish.
 rosrun ros_graph_parser yaml_snaphot -f *file_name.yaml*
 
 Parameter:
-* *file_name.yaml*: the name of the file. It will be saved in the resource folder of the ros_graph_parser package (ensure that you have the permission).
+* *file_name.yaml*: the name of the file. It will be saved in the "result" folder of the ros_graph_parser package (ensure that you have the permission).
 
 ### ROS Node
 This is meant to be runned continually. This node provides a service to be used to acquire a YAML dumped format scan of the ROS Graph
@@ -27,4 +27,4 @@ rosrun ros_graph_parser java_snapshot  *ros_model_file* *ros_system_file* *syste
 * *system_name*: name of the system (check ros_model syntax)
 * *package_name*" name of the package (check ros_model syntax)
 
-All the files will be saved in the resources folder of the ros_graph_parser.
+All the files will be saved in the "result" folder of the ros_graph_parser.

--- a/result/model.ros
+++ b/result/model.ros
@@ -10,20 +10,8 @@ PackageSet { package {
 }},
     Artifact /gazebo {
       node Node { name /gazebo
-
-        publisher {
-          Publisher { name '/iiwa/PositionJointInterface_trajectory_controller/state' message 'control_msgs.JointTrajectoryControllerState'},
-          Publisher { name '/gazebo/model_states' message 'gazebo_msgs.ModelStates'},
-          Publisher { name '/gazebo/parameter_updates' message 'dynamic_reconfigure.Config'},
-          Publisher { name '/iiwa/joint_states' message 'sensor_msgs.JointState'},
-          Publisher { name '/iiwa/state/CartesianWrench' message 'geometry_msgs.WrenchStamped'},
-          Publisher { name '/gazebo/link_states' message 'gazebo_msgs.LinkStates'},
-          Publisher { name '/gazebo/parameter_descriptions' message 'dynamic_reconfigure.ConfigDescription'}}
-        subscriber {
-          Subscriber { name '/iiwa/PositionJointInterface_trajectory_controller/command' message 'trajectory_msgs.JointTrajectory'},
-          Subscriber { name '/gazebo/set_model_state' message 'gazebo_msgs.ModelState'},
-          Subscriber { name '/gazebo/set_link_state' message 'gazebo_msgs.LinkState'}}
-        serviceserver {
+				
+	serviceserver {
           ServiceServer { name '/gazebo/get_model_properties' service 'gazebo_msgs.GetModelProperties'},
           ServiceServer { name '/gazebo/set_model_configuration' service 'gazebo_msgs.SetModelConfiguration'},
           ServiceServer { name '/gazebo/set_light_properties' service 'gazebo_msgs.SetLightProperties'},
@@ -59,6 +47,18 @@ PackageSet { package {
           ServiceServer { name '/gazebo/set_link_properties' service 'gazebo_msgs.SetLinkProperties'},
           ServiceServer { name '/gazebo/apply_body_wrench' service 'gazebo_msgs.ApplyBodyWrench'},
           ServiceServer { name '/gazebo/reset_world' service 'std_srvs.Empty'}}
+        publisher {
+          Publisher { name '/iiwa/PositionJointInterface_trajectory_controller/state' message 'control_msgs.JointTrajectoryControllerState'},
+          Publisher { name '/gazebo/model_states' message 'gazebo_msgs.ModelStates'},
+          Publisher { name '/gazebo/parameter_updates' message 'dynamic_reconfigure.Config'},
+          Publisher { name '/iiwa/joint_states' message 'sensor_msgs.JointState'},
+          Publisher { name '/iiwa/state/CartesianWrench' message 'geometry_msgs.WrenchStamped'},
+          Publisher { name '/gazebo/link_states' message 'gazebo_msgs.LinkStates'},
+          Publisher { name '/gazebo/parameter_descriptions' message 'dynamic_reconfigure.ConfigDescription'}}
+        subscriber {
+          Subscriber { name '/iiwa/PositionJointInterface_trajectory_controller/command' message 'trajectory_msgs.JointTrajectory'},
+          Subscriber { name '/gazebo/set_model_state' message 'gazebo_msgs.ModelState'},
+          Subscriber { name '/gazebo/set_link_state' message 'gazebo_msgs.LinkState'}}
         actionserver {
           ActionServer { name '/iiwa/PositionJointInterface_trajectory_controller/follow_joint_trajectory/' action 'control_msgs.FollowJointTrajectory'}}}
-}}}
+}}}}}

--- a/result/system.rossystem
+++ b/result/system.rossystem
@@ -2,17 +2,12 @@ RosSystem { Name 'mysystem'
     RosComponents ( 
         ComponentInterface { name '/iiwa/robot_state_publisher'
             RosSubscribers {
-<<<<<<< 9a784935e345e3598d7bc93ea6a347ac6ffc084a
                 RosSubscriber '/iiwa/joint_states' {RefSubscriber 'mypackage./iiwa/robot_state_publisher./iiwa/robot_state_publisher./iiwa/joint_states'}}
-=======
-                RosSubscribers '/iiwa/joint_states' {RefSubscriber 'mypackage./iiwa/robot_state_publisher./iiwa/robot_state_publisher./iiwa/joint_states'}}
->>>>>>> fixing java syntax
 },
         ComponentInterface { name '/iiwa/controller_spawner'
 },
         ComponentInterface { name '/gazebo'
             RosPublishers {
-<<<<<<< 9a784935e345e3598d7bc93ea6a347ac6ffc084a
                 RosPublisher '/gazebo/model_states' {RefPublisher 'mypackage./gazebo./gazebo./gazebo/model_states'},
                 RosPublisher '/iiwa/joint_states' {RefPublisher 'mypackage./gazebo./gazebo./iiwa/joint_states'},
                 RosPublisher '/iiwa/state/CartesianWrench' {RefPublisher 'mypackage./gazebo./gazebo./iiwa/state/CartesianWrench'},
@@ -62,56 +57,5 @@ RosSystem { Name 'mysystem'
                 RosServiceServer '/gazebo/clear_joint_forces' {RefServer 'mypackage./gazebo./gazebo./gazebo/clear_joint_forces'}}
             RosActionServers {
                 RosActionServer '/iiwa/PositionJointInterface_trajectory_controller/follow_joint_trajectory/' {RefServer 'mypackage./gazebo./gazebo./iiwa/PositionJointInterface_trajectory_controller/follow_joint_trajectory/'}}
-=======
-                RosPublishers '/iiwa/PositionJointInterface_trajectory_controller/state' {RefPublisher 'mypackage./gazebo./gazebo./iiwa/PositionJointInterface_trajectory_controller/state'},
-                RosPublishers '/gazebo/model_states' {RefPublisher 'mypackage./gazebo./gazebo./gazebo/model_states'},
-                RosPublishers '/gazebo/parameter_updates' {RefPublisher 'mypackage./gazebo./gazebo./gazebo/parameter_updates'},
-                RosPublishers '/iiwa/joint_states' {RefPublisher 'mypackage./gazebo./gazebo./iiwa/joint_states'},
-                RosPublishers '/iiwa/state/CartesianWrench' {RefPublisher 'mypackage./gazebo./gazebo./iiwa/state/CartesianWrench'},
-                RosPublishers '/gazebo/link_states' {RefPublisher 'mypackage./gazebo./gazebo./gazebo/link_states'},
-                RosPublishers '/gazebo/parameter_descriptions' {RefPublisher 'mypackage./gazebo./gazebo./gazebo/parameter_descriptions'}}
-            RosSubscribers {
-                RosSubscribers '/iiwa/PositionJointInterface_trajectory_controller/command' {RefSubscriber 'mypackage./gazebo./gazebo./iiwa/PositionJointInterface_trajectory_controller/command'},
-                RosSubscribers '/gazebo/set_model_state' {RefSubscriber 'mypackage./gazebo./gazebo./gazebo/set_model_state'},
-                RosSubscribers '/gazebo/set_link_state' {RefSubscriber 'mypackage./gazebo./gazebo./gazebo/set_link_state'}}
-            RosSrvServers {
-                RosSrvServers '/gazebo/get_model_properties' {RefServer 'mypackage./gazebo./gazebo./gazebo/get_model_properties'},
-                RosSrvServers '/gazebo/set_model_configuration' {RefServer 'mypackage./gazebo./gazebo./gazebo/set_model_configuration'},
-                RosSrvServers '/gazebo/set_light_properties' {RefServer 'mypackage./gazebo./gazebo./gazebo/set_light_properties'},
-                RosSrvServers '/gazebo/get_world_properties' {RefServer 'mypackage./gazebo./gazebo./gazebo/get_world_properties'},
-                RosSrvServers '/iiwa/controller_manager/list_controllers' {RefServer 'mypackage./gazebo./gazebo./iiwa/controller_manager/list_controllers'},
-                RosSrvServers '/gazebo/delete_light' {RefServer 'mypackage./gazebo./gazebo./gazebo/delete_light'},
-                RosSrvServers '/gazebo/clear_joint_forces' {RefServer 'mypackage./gazebo./gazebo./gazebo/clear_joint_forces'},
-                RosSrvServers '/gazebo/pause_physics' {RefServer 'mypackage./gazebo./gazebo./gazebo/pause_physics'},
-                RosSrvServers '/iiwa/controller_manager/unload_controller' {RefServer 'mypackage./gazebo./gazebo./iiwa/controller_manager/unload_controller'},
-                RosSrvServers '/gazebo/spawn_sdf_model' {RefServer 'mypackage./gazebo./gazebo./gazebo/spawn_sdf_model'},
-                RosSrvServers '/gazebo/get_joint_properties' {RefServer 'mypackage./gazebo./gazebo./gazebo/get_joint_properties'},
-                RosSrvServers '/gazebo/set_model_state' {RefServer 'mypackage./gazebo./gazebo./gazebo/set_model_state'},
-                RosSrvServers '/gazebo/unpause_physics' {RefServer 'mypackage./gazebo./gazebo./gazebo/unpause_physics'},
-                RosSrvServers '/gazebo/delete_model' {RefServer 'mypackage./gazebo./gazebo./gazebo/delete_model'},
-                RosSrvServers '/gazebo/get_light_properties' {RefServer 'mypackage./gazebo./gazebo./gazebo/get_light_properties'},
-                RosSrvServers '/gazebo/get_link_properties' {RefServer 'mypackage./gazebo./gazebo./gazebo/get_link_properties'},
-                RosSrvServers '/gazebo/clear_body_wrenches' {RefServer 'mypackage./gazebo./gazebo./gazebo/clear_body_wrenches'},
-                RosSrvServers '/gazebo/set_parameters' {RefServer 'mypackage./gazebo./gazebo./gazebo/set_parameters'},
-                RosSrvServers '/gazebo/set_physics_properties' {RefServer 'mypackage./gazebo./gazebo./gazebo/set_physics_properties'},
-                RosSrvServers '/gazebo/apply_joint_effort' {RefServer 'mypackage./gazebo./gazebo./gazebo/apply_joint_effort'},
-                RosSrvServers '/iiwa/controller_manager/reload_controller_libraries' {RefServer 'mypackage./gazebo./gazebo./iiwa/controller_manager/reload_controller_libraries'},
-                RosSrvServers '/gazebo/get_model_state' {RefServer 'mypackage./gazebo./gazebo./gazebo/get_model_state'},
-                RosSrvServers '/iiwa/controller_manager/switch_controller' {RefServer 'mypackage./gazebo./gazebo./iiwa/controller_manager/switch_controller'},
-                RosSrvServers '/gazebo/get_physics_properties' {RefServer 'mypackage./gazebo./gazebo./gazebo/get_physics_properties'},
-                RosSrvServers '/gazebo/reset_simulation' {RefServer 'mypackage./gazebo./gazebo./gazebo/reset_simulation'},
-                RosSrvServers '/iiwa/controller_manager/load_controller' {RefServer 'mypackage./gazebo./gazebo./iiwa/controller_manager/load_controller'},
-                RosSrvServers '/iiwa/PositionJointInterface_trajectory_controller/query_state' {RefServer 'mypackage./gazebo./gazebo./iiwa/PositionJointInterface_trajectory_controller/query_state'},
-                RosSrvServers '/gazebo/spawn_urdf_model' {RefServer 'mypackage./gazebo./gazebo./gazebo/spawn_urdf_model'},
-                RosSrvServers '/gazebo/set_link_state' {RefServer 'mypackage./gazebo./gazebo./gazebo/set_link_state'},
-                RosSrvServers '/gazebo/set_joint_properties' {RefServer 'mypackage./gazebo./gazebo./gazebo/set_joint_properties'},
-                RosSrvServers '/gazebo/get_link_state' {RefServer 'mypackage./gazebo./gazebo./gazebo/get_link_state'},
-                RosSrvServers '/iiwa/controller_manager/list_controller_types' {RefServer 'mypackage./gazebo./gazebo./iiwa/controller_manager/list_controller_types'},
-                RosSrvServers '/gazebo/set_link_properties' {RefServer 'mypackage./gazebo./gazebo./gazebo/set_link_properties'},
-                RosSrvServers '/gazebo/apply_body_wrench' {RefServer 'mypackage./gazebo./gazebo./gazebo/apply_body_wrench'},
-                RosSrvServers '/gazebo/reset_world' {RefServer 'mypackage./gazebo./gazebo./gazebo/reset_world'}}
-            RosActionServers {
-                RosActionServers '/iiwa/PositionJointInterface_trajectory_controller/follow_joint_trajectory/' {RefServer 'mypackage./gazebo./gazebo./iiwa/PositionJointInterface_trajectory_controller/follow_joint_trajectory/'}}
->>>>>>> fixing java syntax
 }
 )}

--- a/src/ros_graph_parser/core_class.py
+++ b/src/ros_graph_parser/core_class.py
@@ -78,13 +78,15 @@ class InterfaceSet(set):
         str_+="}"
         return str_
 
-    def java_format_system_model(self, indent="", name_type="", name_type2="", node_name="", pkg_name=""):
+    def java_format_system_model(self, indent="", name_type="", name_type2="", node_name="", pkg_name="", name_type3=""):
         if len(self) == 0:
             return ""
+        if not name_type3:
+            name_type3 = name_type2
         str_ = ("%sRos%s {\n")%(indent, name_type)
         for elem in self:
             str_ += ("%s    Ros%s '%s' {Ref%s '%s.%s.%s.%s'},\n")%(
-                indent, name_type, elem.resolved, name_type2, pkg_name, node_name, node_name, elem.resolved)
+                indent, name_type3, elem.resolved, name_type2, pkg_name, node_name, node_name, elem.resolved)
         str_ = str_[:-2]
         str_+="}\n"
         return str_
@@ -177,9 +179,9 @@ class Node(object):
     def dump_java_ros_model(self):
         ros_model_str="    Artifact "+self.name+" {\n"
         ros_model_str+="      node Node { name "+ self.name+"\n"
-        ros_model_str+=self.publishers.java_format_ros_model("        ", "Publisher", "message","publisher")
-        ros_model_str+=self.subscribers.java_format_ros_model("        ", "Subscriber", "message", "subscriber")
         ros_model_str+=self.services.java_format_ros_model("        ", "ServiceServer", "service","serviceserver")
+        ros_model_str+=self.publishers.java_format_ros_model("        ", "Publisher", "message","publisher")
+        ros_model_str+=self.subscribers.java_format_ros_model("        ", "Subscriber", "message", "subscriber")       
         ros_model_str+=self.action_servers.java_format_ros_model("        ", "ActionServer", "action","actionserver")
         ros_model_str+=self.action_clients.java_format_ros_model("        ", "ActionClient", "action","actionclient")
         ros_model_str+="}},\n"
@@ -189,7 +191,7 @@ class Node(object):
         system_model_str="        ComponentInterface { name '"+self.name+"'\n"
         system_model_str+=self.publishers.java_format_system_model("            ", "Publishers", "Publisher", self.name, package)
         system_model_str+=self.subscribers.java_format_system_model("            ", "Subscribers", "Subscriber",self.name, package)
-        system_model_str+=self.services.java_format_system_model("            ", "SrvServers", "Server", self.name, package)
+        system_model_str+=self.services.java_format_system_model("            ", "SrvServers", "Server", self.name, package, "ServiceServer")
         system_model_str+=self.action_servers.java_format_system_model("            ", "ActionServers", "Server", self.name, package)
         system_model_str+=self.action_clients.java_format_system_model("            ", "ActionClients", "Client", self.name, package)
         system_model_str+="},\n"

--- a/src/ros_graph_parser/snapshot.py
+++ b/src/ros_graph_parser/snapshot.py
@@ -94,8 +94,8 @@ def dump_java_ros_model(snapshot, ros_model_file, pkg_name):
     ros_model_str+="artifact {\n"
     for node in snapshot:
         ros_model_str+=node.dump_java_ros_model()
-    ros_model_str = ros_model_str[:-3]
-    ros_model_str+="\n}}}"
+    ros_model_str = ros_model_str[:-2]
+    ros_model_str+="\n}}}}"
     with open(ros_model_file, 'w') as outfile:
         outfile.write(ros_model_str)
 


### PR DESCRIPTION
@ipa-led I have tried to fix the ros-model syntax issues. What I found was:

- fixed the element names in the component interface (e.g. RosPublisher instead of RosPublishers in the nested elements, see #5)
- I think in the .ros files the serviceservers should be listed first, otherwise Eclipse shows an error
- I also had an issue with the brackets at the end of the file

@ipa-nhg maybe you can take a look if it is correct now too?